### PR TITLE
Reference SomeAsyncException in catchAsync/tryAsync/catchesAsync docs.

### DIFF
--- a/src/Control/Exception/Safe.hs
+++ b/src/Control/Exception/Safe.hs
@@ -109,7 +109,11 @@ throwIO = throw
 throwM :: (C.MonadThrow m, Exception e) => e -> m a
 throwM = throw
 
--- | Throw an asynchronous exception to another thread
+-- | Throw an asynchronous exception to another thread.
+--
+-- Synchronously typed exceptions will be wrapped into an
+-- `AsyncExceptionWrapper`, see
+-- <https://github.com/fpco/safe-exceptions#determining-sync-vs-async>
 --
 -- It's usually a better idea to use the async package, see
 -- <https://github.com/fpco/safe-exceptions#quickstart>

--- a/src/Control/Exception/Safe.hs
+++ b/src/Control/Exception/Safe.hs
@@ -172,7 +172,9 @@ evaluateDeep action = do
 catchAnyDeep :: (C.MonadCatch m, MonadIO m, NFData a) => m a -> (SomeException -> m a) -> m a
 catchAnyDeep = catchDeep
 
--- | 'catch' without async exception safety
+-- | 'catch' without async exception safety.
+--
+-- Will catch extension types which are children of 'Control.Exception.SomeAsyncException', see <https://github.com/fpco/safe-exceptions#determining-sync-vs-async>
 --
 -- Generally it's better to avoid using this function since we do not want to
 -- recover from async exceptions, see
@@ -269,7 +271,9 @@ tryDeep f = catch (liftM Right (evaluateDeep f)) (return . Left)
 tryAnyDeep :: (C.MonadCatch m, MonadIO m, NFData a) => m a -> m (Either SomeException a)
 tryAnyDeep = tryDeep
 
--- | 'try' without async exception safety
+-- | 'try' without async exception safety.
+--
+-- Will catch extension types which are children of 'Control.Exception.SomeAsyncException', see <https://github.com/fpco/safe-exceptions#determining-sync-vs-async>
 --
 -- Generally it's better to avoid using this function since we do not want to
 -- recover from async exceptions, see
@@ -478,7 +482,9 @@ catches io handlers = io `catch` catchesHandler handlers
 catchesDeep :: (C.MonadCatch m, C.MonadThrow m, MonadIO m, NFData a) => m a -> [Handler m a] -> m a
 catchesDeep io handlers = evaluateDeep io `catch` catchesHandler handlers
 
--- | 'catches' without async exception safety
+-- | 'catches' without async exception safety.
+--
+-- Will catch extension types which are children of 'Control.Exception.SomeAsyncException', see <https://github.com/fpco/safe-exceptions#determining-sync-vs-async>
 --
 -- Generally it's better to avoid using this function since we do not want to
 -- recover from async exceptions, see

--- a/src/Control/Exception/Safe.hs
+++ b/src/Control/Exception/Safe.hs
@@ -172,9 +172,7 @@ evaluateDeep action = do
 catchAnyDeep :: (C.MonadCatch m, MonadIO m, NFData a) => m a -> (SomeException -> m a) -> m a
 catchAnyDeep = catchDeep
 
--- | 'catch' without async exception safety.
---
--- Will catch extension types which are children of 'Control.Exception.SomeAsyncException', see <https://github.com/fpco/safe-exceptions#determining-sync-vs-async>
+-- | 'catch' without async exception safety
 --
 -- Generally it's better to avoid using this function since we do not want to
 -- recover from async exceptions, see
@@ -271,9 +269,7 @@ tryDeep f = catch (liftM Right (evaluateDeep f)) (return . Left)
 tryAnyDeep :: (C.MonadCatch m, MonadIO m, NFData a) => m a -> m (Either SomeException a)
 tryAnyDeep = tryDeep
 
--- | 'try' without async exception safety.
---
--- Will catch extension types which are children of 'Control.Exception.SomeAsyncException', see <https://github.com/fpco/safe-exceptions#determining-sync-vs-async>
+-- | 'try' without async exception safety
 --
 -- Generally it's better to avoid using this function since we do not want to
 -- recover from async exceptions, see
@@ -482,9 +478,7 @@ catches io handlers = io `catch` catchesHandler handlers
 catchesDeep :: (C.MonadCatch m, C.MonadThrow m, MonadIO m, NFData a) => m a -> [Handler m a] -> m a
 catchesDeep io handlers = evaluateDeep io `catch` catchesHandler handlers
 
--- | 'catches' without async exception safety.
---
--- Will catch extension types which are children of 'Control.Exception.SomeAsyncException', see <https://github.com/fpco/safe-exceptions#determining-sync-vs-async>
+-- | 'catches' without async exception safety
 --
 -- Generally it's better to avoid using this function since we do not want to
 -- recover from async exceptions, see


### PR DESCRIPTION
Extended the documentation of catchAsync/tryAsync/catchesAsync linking to the description of the difference between sync and async exceptions.

Originally discussed here https://github.com/snoyberg/mono-traversable/issues/109