### PR TITLE
Bump base bound for GHC 8.2

### DIFF
--- a/safe-exceptions.cabal
+++ b/safe-exceptions.cabal
@@ -16,7 +16,7 @@ cabal-version:       >=1.10
 library
   hs-source-dirs:      src
   exposed-modules:     Control.Exception.Safe
-  build-depends:       base >= 4.7 && < 4.10
+  build-depends:       base >= 4.7 && < 4.11
                      , deepseq >= 1.2 && < 1.5
                      , exceptions >= 0.8 && < 0.9
                      , transformers >= 0.2 && < 0.6


### PR DESCRIPTION
GHC 8.2 comes with base-4.10.
The tests still pass on GHC 8.2 after the bump.