### PR TITLE
Add 'bracketWithException'

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.1.7.0
+
+* Add `bracketWithError`
+
 ## 0.1.6.0
 
 * Reuse the `Handler` definition from `Control.Monad.Catch`

--- a/safe-exceptions.cabal
+++ b/safe-exceptions.cabal
@@ -1,5 +1,5 @@
 name:                safe-exceptions
-version:             0.1.6.0
+version:             0.1.7.0
 synopsis:            Safe, consistent, and easy exception handling
 description:         Please see README.md
 homepage:            https://github.com/fpco/safe-exceptions#readme

--- a/src/Control/Exception/Safe.hs
+++ b/src/Control/Exception/Safe.hs
@@ -376,7 +376,7 @@ withException thing after = C.uninterruptibleMask $ \restore -> do
 
 -- | Async safe version of 'E.bracket'
 --
--- @since 0.1.0.0
+-- @since 0.1.7.0
 bracket :: forall m a b c. C.MonadMask m
         => m a -> (a -> m b) -> (a -> m c) -> m c
 bracket before after = bracketWithError before (const after)

--- a/src/Control/Exception/Safe.hs
+++ b/src/Control/Exception/Safe.hs
@@ -56,6 +56,7 @@ module Control.Exception.Safe
     , withException
     , bracketOnError
     , bracketOnError_
+    , bracketWithError
 
       -- * Coercion to sync and async
     , SyncExceptionWrapper (..)
@@ -378,22 +379,10 @@ withException thing after = C.uninterruptibleMask $ \restore -> do
 -- @since 0.1.0.0
 bracket :: forall m a b c. C.MonadMask m
         => m a -> (a -> m b) -> (a -> m c) -> m c
-bracket before after thing = C.mask $ \restore -> do
-    x <- before
-    res1 <- C.try $ restore (thing x)
-    case res1 of
-        Left (e1 :: SomeException) -> do
-            -- explicitly ignore exceptions from after. We know that
-            -- no async exceptions were thrown there, so therefore
-            -- the stronger exception must come from thing
-            --
-            -- https://github.com/fpco/safe-exceptions/issues/2
-            _ :: Either SomeException b <-
-                C.try $ C.uninterruptibleMask_ $ after x
-            C.throwM e1
-        Right y -> do
-            _ <- C.uninterruptibleMask_ $ after x
-            return y
+bracket before after = bracketWithError before after'
+  where
+    after' :: Maybe SomeException -> a -> m b
+    after' = const after
 
 -- | Async safe version of 'E.bracket_'
 --
@@ -438,6 +427,29 @@ bracketOnError before after thing = C.mask $ \restore -> do
 -- @since 0.1.0.0
 bracketOnError_ :: C.MonadMask m => m a -> m b -> m c -> m c
 bracketOnError_ before after thing = bracketOnError before (const after) (const thing)
+
+-- | Async safe version of 'E.bracket' with access to the exception in the
+-- cleanup action.
+--
+-- @since 0.1.0.0
+bracketWithError :: forall m a b c e. (C.MonadMask m, Exception e)
+        => m a -> (Maybe e -> a -> m b) -> (a -> m c) -> m c
+bracketWithError before after thing = C.mask $ \restore -> do
+    x <- before
+    res1 <- C.try $ restore (thing x)
+    case res1 of
+        Left (e1 :: SomeException) -> do
+            -- explicitly ignore exceptions from after. We know that
+            -- no async exceptions were thrown there, so therefore
+            -- the stronger exception must come from thing
+            --
+            -- https://github.com/fpco/safe-exceptions/issues/2
+            _ :: Either SomeException b <-
+                C.try $ C.uninterruptibleMask_ $ after (C.fromException e1) x
+            C.throwM e1
+        Right y -> do
+            _ <- C.uninterruptibleMask_ $ after Nothing x
+            return y
 
 -- | Wrap up an asynchronous exception to be treated as a synchronous
 -- exception


### PR DESCRIPTION
This generalization of `bracket` can be used to report the exception in the cleanup handler. A similar combinator is used in Cardano SL, we need it in order to proceed with migration to `safe-exceptions`.