### PR TITLE
Add HasCallStack to functions (resolves #40)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        resolver: [nightly, lts-16, lts-14, lts-12]
+        resolver: [nightly, lts-21, lts-20, lts-19, lts-18, lts-16, lts-14, lts-12]
 
     steps:
       - name: Clone project
@@ -26,11 +26,5 @@ jobs:
             set -ex
             stack upgrade
             stack --version
-
-            # Work around for https://github.com/commercialhaskell/stack/pull/5577
-            if [[ "${{ runner.os }}" = 'Windows' ]]
-            then
-              rm C:/ProgramData/Chocolatey/bin/ghc*
-            fi
 
             stack test --fast --no-terminal --resolver=${{ matrix.resolver }}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for safe-exceptions
 
+## 0.1.7.4
+
+* Add `HasCallStack` when `exceptions >= 0.10.6` [#41](https://github.com/fpco/safe-exceptions/issues/41)
+
 ## 0.1.7.3
 
 * Allow transformers 0.6 [#39](https://github.com/fpco/safe-exceptions/issues/39)

--- a/safe-exceptions.cabal
+++ b/safe-exceptions.cabal
@@ -1,5 +1,5 @@
 name:                safe-exceptions
-version:             0.1.7.3
+version:             0.1.7.4
 synopsis:            Safe, consistent, and easy exception handling
 description:         Please see README.md
 homepage:            https://github.com/fpco/safe-exceptions#readme

--- a/src/Control/Exception/Safe.hs
+++ b/src/Control/Exception/Safe.hs
@@ -102,22 +102,65 @@ import GHC.Stack (prettySrcLoc)
 import GHC.Stack.Types (HasCallStack, CallStack, getCallStack)
 #endif
 
+#if MIN_VERSION_base(4,9,0) && MIN_VERSION_exceptions(0,10,6)
+import GHC.Stack (withFrozenCallStack)
+#endif
+
+-- The exceptions package that safe-exceptions is based on added HasCallStack
+-- to many of its functions in 0.10.6:
+--
+-- https://github.com/ekmett/exceptions/pull/90
+-- https://github.com/ekmett/exceptions/pull/92
+--
+-- We make the same change here. The following comment has been lifted
+-- verbatim from exceptions:
+--
+-- We use the following bit of CPP to enable the use of HasCallStack
+-- constraints without breaking the build for pre-8.0 GHCs, which did not
+-- provide GHC.Stack. We are careful to always write constraints like this:
+--
+--   HAS_CALL_STACK => MonadThrow m => ...
+--
+-- Instead of like this:
+--
+--   (HAS_CALL_STACK, MonadThrow e) => ...
+--
+-- The latter is equivalent to (() :: Constraint, MonadThrow e) => ..., which
+-- requires ConstraintKinds. More importantly, it's slightly less efficient,
+-- since it requires passing an empty constraint tuple dictionary around.
+--
+-- Note that we do /not/ depend on the call-stack compatibility library to
+-- provide HasCallStack on older GHCs. We tried this at one point, but we
+-- discovered that downstream libraries failed to build because combining
+-- call-stack with GeneralizedNewtypeDeriving on older GHCs would require the
+-- use of ConstraintKinds/FlexibleContexts, which downstream libraries did not
+-- enable. (See #91.) The CPP approach that we use now, while somewhat clunky,
+-- avoids these issues by not requiring any additional language extensions for
+-- downstream users.
+#if MIN_VERSION_base(4,9,0) && MIN_VERSION_exceptions(0,10,6)
+# define HAS_CALL_STACK HasCallStack
+#else
+# define HAS_CALL_STACK ()
+withFrozenCallStack :: a -> a
+withFrozenCallStack a = a
+#endif
+
 -- | Synchronously throw the given exception
 --
 -- @since 0.1.0.0
-throw :: (C.MonadThrow m, Exception e) => e -> m a
+throw :: HAS_CALL_STACK => (C.MonadThrow m, Exception e) => e -> m a
 throw = C.throwM . toSyncException
 
 -- | Synonym for 'throw'
 --
 -- @since 0.1.0.0
-throwIO :: (C.MonadThrow m, Exception e) => e -> m a
+throwIO :: HAS_CALL_STACK => (C.MonadThrow m, Exception e) => e -> m a
 throwIO = throw
 
 -- | Synonym for 'throw'
 --
 -- @since 0.1.0.0
-throwM :: (C.MonadThrow m, Exception e) => e -> m a
+throwM :: HAS_CALL_STACK => (C.MonadThrow m, Exception e) => e -> m a
 throwM = throw
 
 -- | A convenience function for throwing a user error. This is useful
@@ -183,7 +226,7 @@ instance Exception StringException
 -- <https://github.com/fpco/safe-exceptions#quickstart>
 --
 -- @since 0.1.0.0
-throwTo :: (Exception e, MonadIO m) => ThreadId -> e -> m ()
+throwTo :: HAS_CALL_STACK => (Exception e, MonadIO m) => ThreadId -> e -> m ()
 throwTo tid = liftIO . E.throwTo tid . toAsyncException
 
 -- | Generate a pure value which, when forced, will synchronously
@@ -193,14 +236,14 @@ throwTo tid = liftIO . E.throwTo tid . toAsyncException
 -- see <https://github.com/fpco/safe-exceptions#quickstart>
 --
 -- @since 0.1.0.0
-impureThrow :: Exception e => e -> a
+impureThrow :: HAS_CALL_STACK => Exception e => e -> a
 impureThrow = E.throw . toSyncException
 
 -- | Same as upstream 'C.catch', but will not catch asynchronous
 -- exceptions
 --
 -- @since 0.1.0.0
-catch :: (C.MonadCatch m, Exception e) => m a -> (e -> m a) -> m a
+catch :: HAS_CALL_STACK => (C.MonadCatch m, Exception e) => m a -> (e -> m a) -> m a
 catch f g = f `C.catch` \e ->
     if isSyncException e
         then g e
@@ -211,22 +254,22 @@ catch f g = f `C.catch` \e ->
 -- | 'C.catch' specialized to only catching 'E.IOException's
 --
 -- @since 0.1.3.0
-catchIO :: C.MonadCatch m => m a -> (E.IOException -> m a) -> m a
-catchIO = C.catch
+catchIO :: HAS_CALL_STACK => C.MonadCatch m => m a -> (E.IOException -> m a) -> m a
+catchIO = withFrozenCallStack C.catch
 
 -- | 'catch' specialized to catch all synchronous exception
 --
 -- @since 0.1.0.0
-catchAny :: C.MonadCatch m => m a -> (SomeException -> m a) -> m a
-catchAny = catch
+catchAny :: HAS_CALL_STACK => C.MonadCatch m => m a -> (SomeException -> m a) -> m a
+catchAny = withFrozenCallStack catch
 
 -- | Same as 'catch', but fully force evaluation of the result value
 -- to find all impure exceptions.
 --
 -- @since 0.1.1.0
-catchDeep :: (C.MonadCatch m, MonadIO m, Exception e, NFData a)
+catchDeep :: HAS_CALL_STACK => (C.MonadCatch m, MonadIO m, Exception e, NFData a)
           => m a -> (e -> m a) -> m a
-catchDeep = catch . evaluateDeep
+catchDeep = withFrozenCallStack catch . evaluateDeep
 
 -- | Internal helper function
 evaluateDeep :: (MonadIO m, NFData a) => m a -> m a
@@ -237,8 +280,8 @@ evaluateDeep action = do
 -- | 'catchDeep' specialized to catch all synchronous exception
 --
 -- @since 0.1.1.0
-catchAnyDeep :: (C.MonadCatch m, MonadIO m, NFData a) => m a -> (SomeException -> m a) -> m a
-catchAnyDeep = catchDeep
+catchAnyDeep :: HAS_CALL_STACK => (C.MonadCatch m, MonadIO m, NFData a) => m a -> (SomeException -> m a) -> m a
+catchAnyDeep = withFrozenCallStack catchDeep
 
 -- | 'catch' without async exception safety
 --
@@ -247,7 +290,7 @@ catchAnyDeep = catchDeep
 -- <https://github.com/fpco/safe-exceptions#quickstart>
 --
 -- @since 0.1.0.0
-catchAsync :: (C.MonadCatch m, Exception e) => m a -> (e -> m a) -> m a
+catchAsync :: HAS_CALL_STACK => (C.MonadCatch m, Exception e) => m a -> (e -> m a) -> m a
 catchAsync = C.catch
 
 -- | 'catchJust' is like 'catch' but it takes an extra argument which
@@ -255,39 +298,39 @@ catchAsync = C.catch
 -- exceptions we're interested in.
 --
 -- @since 0.1.4.0
-catchJust :: (C.MonadCatch m, Exception e) => (e -> Maybe b) -> m a -> (b -> m a) -> m a
-catchJust f a b = a `catch` \e -> maybe (throwM e) b $ f e
+catchJust :: HAS_CALL_STACK => (C.MonadCatch m, Exception e) => (e -> Maybe b) -> m a -> (b -> m a) -> m a
+catchJust f a b = withFrozenCallStack a `catch` \e -> maybe (throwM e) b $ f e
 
 -- | Flipped version of 'catch'
 --
 -- @since 0.1.0.0
-handle :: (C.MonadCatch m, Exception e) => (e -> m a) -> m a -> m a
-handle = flip catch
+handle :: HAS_CALL_STACK => (C.MonadCatch m, Exception e) => (e -> m a) -> m a -> m a
+handle = flip (withFrozenCallStack catch)
 
 -- | 'C.handle' specialized to only catching 'E.IOException's
 --
 -- @since 0.1.3.0
-handleIO :: C.MonadCatch m => (E.IOException -> m a) -> m a -> m a
-handleIO = C.handle
+handleIO :: HAS_CALL_STACK => C.MonadCatch m => (E.IOException -> m a) -> m a -> m a
+handleIO = withFrozenCallStack C.handle
 
 
 -- | Flipped version of 'catchAny'
 --
 -- @since 0.1.0.0
-handleAny :: C.MonadCatch m => (SomeException -> m a) -> m a -> m a
-handleAny = flip catchAny
+handleAny :: HAS_CALL_STACK => C.MonadCatch m => (SomeException -> m a) -> m a -> m a
+handleAny = flip (withFrozenCallStack catchAny)
 
 -- | Flipped version of 'catchDeep'
 --
 -- @since 0.1.1.0
-handleDeep :: (C.MonadCatch m, Exception e, MonadIO m, NFData a) => (e -> m a) -> m a -> m a
-handleDeep = flip catchDeep
+handleDeep :: HAS_CALL_STACK => (C.MonadCatch m, Exception e, MonadIO m, NFData a) => (e -> m a) -> m a -> m a
+handleDeep = flip (withFrozenCallStack catchDeep)
 
 -- | Flipped version of 'catchAnyDeep'
 --
 -- @since 0.1.1.0
-handleAnyDeep :: (C.MonadCatch m, MonadIO m, NFData a) => (SomeException -> m a) -> m a -> m a
-handleAnyDeep = flip catchAnyDeep
+handleAnyDeep :: HAS_CALL_STACK => (C.MonadCatch m, MonadIO m, NFData a) => (SomeException -> m a) -> m a -> m a
+handleAnyDeep = flip (withFrozenCallStack catchAnyDeep)
 
 -- | Flipped version of 'catchAsync'
 --
@@ -296,46 +339,46 @@ handleAnyDeep = flip catchAnyDeep
 -- <https://github.com/fpco/safe-exceptions#quickstart>
 --
 -- @since 0.1.0.0
-handleAsync :: (C.MonadCatch m, Exception e) => (e -> m a) -> m a -> m a
+handleAsync :: HAS_CALL_STACK => (C.MonadCatch m, Exception e) => (e -> m a) -> m a -> m a
 handleAsync = C.handle
 
 -- | Flipped 'catchJust'.
 --
 -- @since 0.1.4.0
-handleJust :: (C.MonadCatch m, Exception e) => (e -> Maybe b) -> (b -> m a) -> m a -> m a
-handleJust f = flip (catchJust f)
+handleJust :: HAS_CALL_STACK => (C.MonadCatch m, Exception e) => (e -> Maybe b) -> (b -> m a) -> m a -> m a
+handleJust f = flip (withFrozenCallStack catchJust f)
 
 -- | Same as upstream 'C.try', but will not catch asynchronous
 -- exceptions
 --
 -- @since 0.1.0.0
-try :: (C.MonadCatch m, E.Exception e) => m a -> m (Either e a)
-try f = catch (liftM Right f) (return . Left)
+try :: HAS_CALL_STACK => (C.MonadCatch m, E.Exception e) => m a -> m (Either e a)
+try f = withFrozenCallStack catch (liftM Right f) (return . Left)
 
 -- | 'C.try' specialized to only catching 'E.IOException's
 --
 -- @since 0.1.3.0
-tryIO :: C.MonadCatch m => m a -> m (Either E.IOException a)
-tryIO = C.try
+tryIO :: HAS_CALL_STACK => C.MonadCatch m => m a -> m (Either E.IOException a)
+tryIO = withFrozenCallStack C.try
 
 -- | 'try' specialized to catch all synchronous exceptions
 --
 -- @since 0.1.0.0
-tryAny :: C.MonadCatch m => m a -> m (Either SomeException a)
-tryAny = try
+tryAny :: HAS_CALL_STACK => C.MonadCatch m => m a -> m (Either SomeException a)
+tryAny = withFrozenCallStack try
 
 -- | Same as 'try', but fully force evaluation of the result value
 -- to find all impure exceptions.
 --
 -- @since 0.1.1.0
-tryDeep :: (C.MonadCatch m, MonadIO m, E.Exception e, NFData a) => m a -> m (Either e a)
-tryDeep f = catch (liftM Right (evaluateDeep f)) (return . Left)
+tryDeep :: HAS_CALL_STACK => (C.MonadCatch m, MonadIO m, E.Exception e, NFData a) => m a -> m (Either e a)
+tryDeep f = withFrozenCallStack catch (liftM Right (evaluateDeep f)) (return . Left)
 
 -- | 'tryDeep' specialized to catch all synchronous exceptions
 --
 -- @since 0.1.1.0
-tryAnyDeep :: (C.MonadCatch m, MonadIO m, NFData a) => m a -> m (Either SomeException a)
-tryAnyDeep = tryDeep
+tryAnyDeep :: HAS_CALL_STACK => (C.MonadCatch m, MonadIO m, NFData a) => m a -> m (Either SomeException a)
+tryAnyDeep = withFrozenCallStack tryDeep
 
 -- | 'try' without async exception safety
 --
@@ -344,28 +387,28 @@ tryAnyDeep = tryDeep
 -- <https://github.com/fpco/safe-exceptions#quickstart>
 --
 -- @since 0.1.0.0
-tryAsync :: (C.MonadCatch m, E.Exception e) => m a -> m (Either e a)
+tryAsync :: HAS_CALL_STACK => (C.MonadCatch m, E.Exception e) => m a -> m (Either e a)
 tryAsync = C.try
 
 -- | A variant of 'try' that takes an exception predicate to select
 -- which exceptions are caught.
 --
 -- @since 0.1.4.0
-tryJust :: (C.MonadCatch m, Exception e) => (e -> Maybe b) -> m a -> m (Either b a)
-tryJust f a = catch (Right `liftM` a) (\e -> maybe (throwM e) (return . Left) (f e))
+tryJust :: HAS_CALL_STACK => (C.MonadCatch m, Exception e) => (e -> Maybe b) -> m a -> m (Either b a)
+tryJust f a = withFrozenCallStack catch (Right `liftM` a) (\e -> maybe (throwM e) (return . Left) (f e))
 
 -- | Async safe version of 'E.onException'
 --
 -- @since 0.1.0.0
-onException :: C.MonadMask m => m a -> m b -> m a
-onException thing after = withException thing (\(_ :: SomeException) -> after)
+onException :: HAS_CALL_STACK => C.MonadMask m => m a -> m b -> m a
+onException thing after = withFrozenCallStack withException thing (\(_ :: SomeException) -> after)
 
 -- | Like 'onException', but provides the handler the thrown
 -- exception.
 --
 -- @since 0.1.0.0
-withException :: (C.MonadMask m, E.Exception e) => m a -> (e -> m b) -> m a
-withException thing after = C.uninterruptibleMask $ \restore -> do
+withException :: HAS_CALL_STACK => (C.MonadMask m, E.Exception e) => m a -> (e -> m b) -> m a
+withException thing after = withFrozenCallStack $ C.uninterruptibleMask $ \restore -> do
     fmap fst $ C.generalBracket (pure ()) cAfter (const $ restore thing)
   where
     -- ignore the exception from after, see bracket for explanation
@@ -376,21 +419,21 @@ withException thing after = C.uninterruptibleMask $ \restore -> do
 -- | Async safe version of 'E.bracket'
 --
 -- @since 0.1.0.0
-bracket :: forall m a b c. C.MonadMask m
+bracket :: forall m a b c. HAS_CALL_STACK => C.MonadMask m
         => m a -> (a -> m b) -> (a -> m c) -> m c
-bracket before after = bracketWithError before (const after)
+bracket before after = withFrozenCallStack bracketWithError before (const after)
 
 -- | Async safe version of 'E.bracket_'
 --
 -- @since 0.1.0.0
-bracket_ :: C.MonadMask m => m a -> m b -> m c -> m c
-bracket_ before after thing = bracket before (const after) (const thing)
+bracket_ :: HAS_CALL_STACK => C.MonadMask m => m a -> m b -> m c -> m c
+bracket_ before after thing = withFrozenCallStack bracket before (const after) (const thing)
 
 -- | Async safe version of 'E.finally'
 --
 -- @since 0.1.0.0
-finally :: C.MonadMask m => m a -> m b -> m a
-finally thing after = C.uninterruptibleMask $ \restore -> do
+finally :: HAS_CALL_STACK => C.MonadMask m => m a -> m b -> m a
+finally thing after = withFrozenCallStack $ C.uninterruptibleMask $ \restore -> do
     fmap fst $ C.generalBracket (pure ()) cAfter (const $ restore thing)
   where
     -- ignore the exception from after, see bracket for explanation
@@ -401,9 +444,9 @@ finally thing after = C.uninterruptibleMask $ \restore -> do
 -- | Async safe version of 'E.bracketOnError'
 --
 -- @since 0.1.0.0
-bracketOnError :: forall m a b c. C.MonadMask m
+bracketOnError :: forall m a b c. HAS_CALL_STACK => C.MonadMask m
                => m a -> (a -> m b) -> (a -> m c) -> m c
-bracketOnError before after thing = fmap fst $ C.generalBracket before cAfter thing
+bracketOnError before after thing = fmap fst $ withFrozenCallStack C.generalBracket before cAfter thing
   where
     -- ignore the exception from after, see bracket for explanation
     cAfter x (C.ExitCaseException se) =
@@ -415,16 +458,16 @@ bracketOnError before after thing = fmap fst $ C.generalBracket before cAfter th
 -- computation is not required.
 --
 -- @since 0.1.0.0
-bracketOnError_ :: C.MonadMask m => m a -> m b -> m c -> m c
-bracketOnError_ before after thing = bracketOnError before (const after) (const thing)
+bracketOnError_ :: HAS_CALL_STACK => C.MonadMask m => m a -> m b -> m c -> m c
+bracketOnError_ before after thing = withFrozenCallStack bracketOnError before (const after) (const thing)
 
 -- | Async safe version of 'E.bracket' with access to the exception in the
 -- cleanup action.
 --
 -- @since 0.1.7.0
-bracketWithError :: forall m a b c. C.MonadMask m
+bracketWithError :: forall m a b c. HAS_CALL_STACK => C.MonadMask m
         => m a -> (Maybe SomeException -> a -> m b) -> (a -> m c) -> m c
-bracketWithError before after thing = fmap fst $ C.generalBracket before cAfter thing
+bracketWithError before after thing = fmap fst $ withFrozenCallStack C.generalBracket before cAfter thing
   where
     cAfter x (C.ExitCaseException se) =
         C.uninterruptibleMask_ $ ignoreExceptions $ after (Just se) x
@@ -534,15 +577,15 @@ displayException = show
 -- exceptions
 --
 -- @since 0.1.2.0
-catches :: (C.MonadCatch m, C.MonadThrow m) => m a -> [Handler m a] -> m a
-catches io handlers = io `catch` catchesHandler handlers
+catches :: HAS_CALL_STACK => (C.MonadCatch m, C.MonadThrow m) => m a -> [Handler m a] -> m a
+catches io handlers = withFrozenCallStack io `catch` catchesHandler handlers
 
 -- | Same as 'catches', but fully force evaluation of the result value
 -- to find all impure exceptions.
 --
 -- @since 0.1.2.0
-catchesDeep :: (C.MonadCatch m, C.MonadThrow m, MonadIO m, NFData a) => m a -> [Handler m a] -> m a
-catchesDeep io handlers = evaluateDeep io `catch` catchesHandler handlers
+catchesDeep :: HAS_CALL_STACK => (C.MonadCatch m, C.MonadThrow m, MonadIO m, NFData a) => m a -> [Handler m a] -> m a
+catchesDeep io handlers = withFrozenCallStack evaluateDeep io `catch` catchesHandler handlers
 
 -- | 'catches' without async exception safety
 --
@@ -551,10 +594,10 @@ catchesDeep io handlers = evaluateDeep io `catch` catchesHandler handlers
 -- <https://github.com/fpco/safe-exceptions#quickstart>
 --
 -- @since 0.1.2.0
-catchesAsync :: (C.MonadCatch m, C.MonadThrow m) => m a -> [Handler m a] -> m a
+catchesAsync :: HAS_CALL_STACK => (C.MonadCatch m, C.MonadThrow m) => m a -> [Handler m a] -> m a
 catchesAsync io handlers = io `catchAsync` catchesHandler handlers
 
-catchesHandler :: (C.MonadThrow m) => [Handler m a] -> SomeException -> m a
+catchesHandler :: HAS_CALL_STACK => (C.MonadThrow m) => [Handler m a] -> SomeException -> m a
 catchesHandler handlers e = foldr tryHandler (C.throwM e) handlers
     where tryHandler (Handler handler) res
               = case fromException e of


### PR DESCRIPTION
Resolves #40. I'm putting this up now for visibility, though it's probably best to wait until GHC 9.6 can be added to CI so the new code can actually be compiled on CI (9.6 is the [first GHC](https://gitlab.haskell.org/ghc/ghc/-/wikis/commentary/libraries/version-history) using `exceptions >= 0.10.6` that this PR utilizes).

Couple notes:

1. In addition to the `MIN_VERSION_base(4,9,0)` guard for `HasCallStack`, I added a condition for `MIN_VERSION_exceptions(0,10,6)`, since there is no reason to add `HasCallStack` for any lower versions (also it would trip `-Wredundant-constraints`, though that doesn't appear to be on).

2. It is not entirely clear to me when it is best to use `withFrozenCallStack`, so I followed the [original PR's](https://github.com/ekmett/exceptions/pull/90/files) lead. The following table summarizes the situation:

    * LHS listing `exceptions` functions using `withFrozenCallStack`
    * RHS is either the `safe-exceptions` counterpart, or a note that the original `exceptions` function was re-exported, so we do not have to do anything.
    
    Additionally, `safe-exceptions` has a few functions that do not exist in `exceptions`, yet seem they like they should also use `withFrozenCallStack`, so I added those as well, and listed them as `N/A`.

    <details>
        <summary>Click to expand table</summary>

    | `exceptions`           | `safe-exceptions`  |
    |------------------------|--------------------|
    | `mask_`                | Re-exported        |
    | `uninterruptibleMask_` | Re-exported        |
    | `catchAll`             | `catchAny`         |
    | `catchIOError`         | Re-exported        |
    | `catchIf`              | N/A                |
    | `catchJust`            | `catchJust`        |
    | `handle`               | `handle`           |
    | `handleIOError`        | Re-exported        |
    | `handleAll`            | `handleAny`        |
    | `handleIf`             | N/A                |
    | `handleJust`           | `handleJust`       |
    | `try`                  | `try`              |
    | `tryJust`              | `tryJust`          |
    | `catches`              | `catches`          |
    | `onException`          | `onException`      |
    | `onError`              | N/A                |
    | `bracket`              | `bracket`          |
    | `bracket_`             | `bracket_`         |
    | `finally`              | `finally`          |
    | `bracketOnError`       | Re-exported        |
    | N/A                    | `catchIO`          |
    | N/A                    | `catchDeep`        |
    | N/A                    | `catchAnyDeep`     |
    | N/A                    | `handleIO`         |
    | N/A                    | `handleAny`        |
    | N/A                    | `handleDeep`       |
    | N/A                    | `handleAnyDeep`    |
    | N/A                    | `tryIO`            |
    | N/A                    | `tryAny`           |
    | N/A                    | `tryDeep`          |
    | N/A                    | `tryAnyDeep`       |
    | N/A                    | `withException`    |
    | N/A                    | `bracketOnError_`  |
    | N/A                    | `bracketWithError` |
    | N/A                    | `catchesDeep`      |

    </details>

Perhaps @parsonsmatt would be kind enough to glance over the `withFrozenCallStack` logic?