### PR TITLE
Allow deepseq-1.5

### DIFF
--- a/safe-exceptions.cabal
+++ b/safe-exceptions.cabal
@@ -17,7 +17,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Control.Exception.Safe
   build-depends:       base >= 4.11 && < 5
-                     , deepseq >= 1.2 && < 1.5
+                     , deepseq >= 1.2 && < 1.6
                      , exceptions >= 0.10 && < 0.11
                      , transformers >= 0.2 && < 0.7
   default-language:    Haskell2010


### PR DESCRIPTION
Concrete motivation is that deepseq-1.5 is bundled with GHC 9.8.1, and hence might be non-reinstallable eg when depending on the `ghc` package.